### PR TITLE
Fix CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,6 @@ find_package(NLopt REQUIRED)
 #set(NLOPT_INCLUDE_PATH "/usr/include" CACHE PATH "Directory containing nlopt.h/hpp")
 include_directories(${NLOPT_INCLUDE_DIRS})
 
-# Add CUDA
-include(cmake_scripts/findAndTestCUDA.cmake)
 
 # Add Qt5
 find_package(Qt5Widgets)

--- a/code/LibEpipolarConsistency/CMakeLists.txt
+++ b/code/LibEpipolarConsistency/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # A library to evaluate a metric of epipolar consistency
-cuda_add_library(LibEpipolarConsistency
+add_library(LibEpipolarConsistency
 	# Common methods for ECC direct and with Radon intermediate
 	EpipolarConsistency.h
 	EpipolarConsistency.cpp
@@ -26,9 +26,9 @@ cuda_add_library(LibEpipolarConsistency
 	RadonIntermediate.h
 	RadonIntermediate.cpp
 	RadonIntermediate.cu
-	OPTIONS -DHAS_CUDA="Cuda Support"
 )
 target_link_libraries(LibEpipolarConsistency LibProjectiveGeometry LibUtilsCuda ${CUDA_CUFFT_LIBRARIES} )
+add_definitions(-DHAS_CUDA="Cuda Support")
 install(FILES EpipolarConsistencyCommon.hxx EpipolarConsistency.h EpipolarConsistencyDirect.h RectifiedFBCC.h RadonIntermediate.h EpipolarConsistencyRadonIntermediate.h DESTINATION include/LibEpipolarConsistency)
 install(TARGETS LibEpipolarConsistency DESTINATION lib EXPORT LibEpipolarConsistency-targets)
 install(EXPORT LibEpipolarConsistency-targets DESTINATION cmake)

--- a/code/LibRayCastBackproject/CMakeLists.txt
+++ b/code/LibRayCastBackproject/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cuda_add_library(LibRayCastBackproject
+add_library(LibRayCastBackproject
 	VolumeRendering.h
 	VolumeRendering.cpp
 	VoxelData.h

--- a/code/LibUtilsCuda/CMakeLists.txt
+++ b/code/LibUtilsCuda/CMakeLists.txt
@@ -6,7 +6,7 @@ if (CUDA_HAVE_GPU)
 	# )
 	# target_link_libraries(TestUtilsCuda LibUtilsCuda LibProjectiveGeometry)
 
-	cuda_add_library(LibUtilsCuda STATIC
+	add_library(LibUtilsCuda STATIC
 		CudaTextureArray.hxx
 		CudaBindlessTexture.h
 		CudaBindlessTexture.cpp
@@ -16,8 +16,8 @@ if (CUDA_HAVE_GPU)
 		CudaAlgorithms.h
 		CudaAlgorithms.cpp
 		CudaConvolution.cu
-		OPTIONS -DHAS_CUDA="Cuda Support"
 	)
+	add_definitions(-DHAS_CUDA="Cuda Support")
 	install(FILES UtilsCuda.hxx CudaTextureArray.hxx CudaMemory.h CudaAlgorithms.h CudaBindlessTexture.h DESTINATION include/LibUtilsCuda)
 
 	install(TARGETS LibUtilsCuda DESTINATION lib EXPORT LibUtilsCuda-targets)

--- a/tools/FluoroTracking/CMakeLists.txt
+++ b/tools/FluoroTracking/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 #remove cuda_
 
-cuda_add_executable(FluoroTracking
+add_executable(FluoroTracking
 	FluoroTracking.cpp
 )
 target_link_libraries( FluoroTracking LibProjectiveGeometry LibEpipolarConsistency LibEpipolarConsistencyGui LibUtilsQt LibUtilsCuda GetSet GetSetGui ${OPENGL_LIBRARIES} ${NLOPT_LIBRARIES})

--- a/tools/Registration/CMakeLists.txt
+++ b/tools/Registration/CMakeLists.txt
@@ -8,7 +8,7 @@ install(TARGETS Registration DESTINATION bin)
 set_property(TARGET Registration PROPERTY FOLDER "EpipolarConsistency") 
 
 
-cuda_add_executable(RegistrationIntensityBased
+add_executable(RegistrationIntensityBased
 	RegistrationIntensityBased.cpp
 	warp3d.cu
 )

--- a/tools/VisualizeECC/CMakeLists.txt
+++ b/tools/VisualizeECC/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cuda_add_executable(VisualizeECC
+add_executable(VisualizeECC
 	draw_epipolar_lines.hxx
 	VisualizeECC.cpp
 )
@@ -8,7 +8,7 @@ qt5_use_modules(VisualizeECC Widgets Svg OpenGL PrintSupport)
 install(TARGETS VisualizeECC DESTINATION bin)
 set_property(TARGET VisualizeECC PROPERTY FOLDER "EpipolarConsistency") 
 
-cuda_add_executable(VisualizeECC_RadonIntermediate
+add_executable(VisualizeECC_RadonIntermediate
 	draw_epipolar_lines.hxx
 	VisualizeECC_RadonIntermediate.cpp
 )
@@ -17,7 +17,7 @@ qt5_use_modules(VisualizeECC_RadonIntermediate Widgets Svg OpenGL PrintSupport)
 install(TARGETS VisualizeECC_RadonIntermediate DESTINATION bin)
 set_property(TARGET VisualizeECC_RadonIntermediate PROPERTY FOLDER "EpipolarConsistency") 
 
-cuda_add_executable(VisualizeECC_ComputedTomography
+add_executable(VisualizeECC_ComputedTomography
 	draw_epipolar_lines.hxx
 	VisualizeECC_ComputedTomography.cpp
 )

--- a/tools/VolumeRendering/CMakeLists.txt
+++ b/tools/VolumeRendering/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cuda_add_executable( VolumeRendering
+add_executable( VolumeRendering
 	volume_renderer.cpp
 )
 target_link_libraries( VolumeRendering LibProjectiveGeometry LibRayCastBackproject LibUtilsCuda LibUtilsQt GetSet GetSetGui)
@@ -7,7 +7,7 @@ qt5_use_modules(VolumeRendering Gui )
 install(TARGETS VolumeRendering RUNTIME DESTINATION bin)
 set_property(TARGET VolumeRendering PROPERTY FOLDER "Utilities")
 
-# cuda_add_executable( Reconstruction
+# add_executable( Reconstruction
 	# reconstruction.cpp
 # )
 # target_link_libraries( Reconstruction LibProjectiveGeometry LibRayCastBackproject LibEpipolarConsistencyGui LibUtilsCuda LibUtilsQt GetSet GetSetGui)


### PR DESCRIPTION
CUDA is now built-in

Maybe still guard the CUDA targets.

```
include(CheckLanguage)
check_language(CUDA)
```

Reference: https://cliutils.gitlab.io/modern-cmake/chapters/packages/CUDA.html